### PR TITLE
Make links-header links gapless

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -166,7 +166,8 @@ a:hover {
 }
 
 .links-header a{
-    margin: 10px;
+    margin: 0;
+    padding: 10px;
     color: black;
 }
 


### PR DESCRIPTION
Currently hovering through the links-header items causes a white splash in between the color splashes. This to me seems to be annoying.